### PR TITLE
Respect database and table permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 dist
 *.egg-info
+*.swp
 
 # dependencies
 /node_modules

--- a/datasette_search_all/__init__.py
+++ b/datasette_search_all/__init__.py
@@ -5,9 +5,9 @@ import json
 
 
 @hookimpl
-def menu_links(datasette):
+def menu_links(datasette, actor):
     async def inner():
-        if await has_searchable_tables(datasette):
+        if await has_searchable_tables(datasette, actor):
             return [
                 {"href": datasette.urls.path("/-/search"), "label": "Search all tables"}
             ]
@@ -16,7 +16,7 @@ def menu_links(datasette):
 
 
 async def search_all(datasette, request):
-    searchable_tables = list(await get_searchable_tables(datasette))
+    searchable_tables = list(await get_searchable_tables(datasette, request.actor))
     tables = [
         {
             "database": database,
@@ -39,12 +39,14 @@ async def search_all(datasette, request):
 
 
 @hookimpl
-def extra_template_vars(template, datasette):
+def extra_template_vars(template, request, datasette):
     if template != "index.html":
         return
     # Add list of searchable tables
     async def inner():
-        searchable_tables = list(await get_searchable_tables(datasette))
+        if not await has_searchable_tables(datasette, request.actor):
+            return {"searchable_tables": []}
+        searchable_tables = list(await get_searchable_tables(datasette, request.actor))
         return {"searchable_tables": searchable_tables}
 
     return inner

--- a/datasette_search_all/utils.py
+++ b/datasette_search_all/utils.py
@@ -1,23 +1,29 @@
-async def iterate_searchable_tables(datasette):
+async def iterate_searchable_tables(datasette, actor):
     for db_name, database in datasette.databases.items():
+        perm_args = (actor, "view-database", (db_name,))
+        if not await datasette.permission_allowed(*perm_args):
+            continue
         hidden_tables = set(await database.hidden_table_names())
         for table in await database.table_names():
             if table in hidden_tables:
+                continue
+            perm_args = (actor, "view-table", (db_name, table))
+            if not await datasette.permission_allowed(*perm_args):
                 continue
             fts_table = await database.fts_table(table)
             if fts_table:
                 yield (db_name, table)
 
 
-async def has_searchable_tables(datasette):
+async def has_searchable_tables(datasette, actor):
     # Return True on the first table we find
-    async for _ in iterate_searchable_tables(datasette):
+    async for _ in iterate_searchable_tables(datasette, actor):
         return True
     return False
 
 
-async def get_searchable_tables(datasette):
+async def get_searchable_tables(datasette, actor):
     tables = []
-    async for table in iterate_searchable_tables(datasette):
+    async for table in iterate_searchable_tables(datasette, actor):
         tables.append(table)
     return tables

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-VERSION = "1.0.1"
+VERSION = "1.1.0"
 
 
 def get_long_description():

--- a/tests/test_search_all.py
+++ b/tests/test_search_all.py
@@ -1,60 +1,93 @@
-import datasette
 from datasette.app import Datasette
 import sqlite_utils
 import pytest
 
 
 @pytest.fixture
-def db_path(tmpdir):
-    path = str(tmpdir / "data.db")
-    db = sqlite_utils.Database(path)
+def db_paths(tmpdir):
+    path1 = str(tmpdir / "data.db")
+    db = sqlite_utils.Database(path1)
     db["creatures"].insert_all(
         [
             {"name": "Cleo", "description": "A medium sized dog"},
             {"name": "Siroco", "description": "A troublesome Kakapo"},
         ]
     )
-    return path
+    path2 = str(tmpdir / "another.db")
+    db = sqlite_utils.Database(path2)
+    db["things"].insert_all(
+        [
+            {"name": "Pencil", "description": "A writing instrument"},
+            {"name": "Wheel", "description": "A basic tool"},
+        ]
+    )
+    return [path1, path2]
+
+
+async def permission_allowed(*args, **kwargs):
+    return True
 
 
 @pytest.mark.asyncio
-async def test_no_form_on_index_if_not_searchable(db_path):
-    datasette = Datasette([db_path])
+async def test_no_form_on_index_if_not_searchable(db_paths):
+    datasette = Datasette(db_paths)
+    datasette.permission_allowed = permission_allowed
     response = await datasette.client.get("/")
     assert response.status_code == 200
     assert '<form action="/-/search" method="get">' not in response.text
 
 
 @pytest.mark.asyncio
-async def test_no_nav_menu_if_not_searchable(db_path):
-    datasette = Datasette([db_path])
+async def test_no_nav_menu_if_not_searchable(db_paths):
+    datasette = Datasette(db_paths)
     response = await datasette.client.get("/")
     assert response.status_code == 200
     assert '<details class="nav-menu">' not in response.text
 
 
 @pytest.mark.asyncio
-async def test_shows_form_on_index_if_searchable(db_path):
-    sqlite_utils.Database(db_path)["creatures"].enable_fts(["name", "description"])
-    datasette = Datasette([db_path])
+async def test_shows_form_on_index_if_searchable(db_paths):
+    sqlite_utils.Database(db_paths[0])["creatures"].enable_fts(["name", "description"])
+    datasette = Datasette(db_paths)
+    datasette.permission_allowed = permission_allowed
     response = await datasette.client.get("/")
     assert response.status_code == 200
     assert '<form action="/-/search" method="get">' in response.text
 
 
 @pytest.mark.asyncio
-async def test_shows_nav_menu_if_searchable(db_path):
-    sqlite_utils.Database(db_path)["creatures"].enable_fts(["name", "description"])
-    datasette = Datasette([db_path])
+async def test_shows_nav_menu_if_searchable(db_paths):
+    sqlite_utils.Database(db_paths[0])["creatures"].enable_fts(["name", "description"])
+    datasette = Datasette(db_paths)
+    datasette.permission_allowed = permission_allowed
     response = await datasette.client.get("/")
     assert response.status_code == 200
     assert '<details class="nav-menu">' in response.text
 
 
 @pytest.mark.asyncio
-async def test_search_page(db_path):
-    sqlite_utils.Database(db_path)["creatures"].enable_fts(["name", "description"])
-    datasette = Datasette([db_path])
+async def test_form_respects_permissions(db_paths):
+    sqlite_utils.Database(db_paths[0])["creatures"].enable_fts(["name", "description"])
+    sqlite_utils.Database(db_paths[1])["things"].enable_fts(["name", "description"])
+    datasette = Datasette(db_paths)
+    async def permission_some_dbs(actor, action, *args, **kwargs):
+        resource = ()
+        if args:
+            resource = args[0]
+        if action == "view-database" and "another" in resource:
+            return False
+        return True
+    datasette.permission_allowed = permission_some_dbs
+    response = await datasette.client.get("/")
+    assert response.status_code == 200
+    assert 'across 1 table' in response.text
+
+
+@pytest.mark.asyncio
+async def test_search_page(db_paths):
+    sqlite_utils.Database(db_paths[0])["creatures"].enable_fts(["name", "description"])
+    datasette = Datasette(db_paths)
+    datasette.permission_allowed = permission_allowed
     response = await datasette.client.get("/-/search?q=dog")
     assert response.status_code == 200
     content = response.text
@@ -69,9 +102,10 @@ async def test_search_page(db_path):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("path", ["/", "/-/search"])
-async def test_base_url(db_path, path):
-    sqlite_utils.Database(db_path)["creatures"].enable_fts(["name", "description"])
-    datasette = Datasette([db_path], config={"base_url": "/foo/"})
+async def test_base_url(db_paths, path):
+    sqlite_utils.Database(db_paths[0])["creatures"].enable_fts(["name", "description"])
+    datasette = Datasette(db_paths, config={"base_url": "/foo/"})
+    datasette.permission_allowed = permission_allowed
     response = await datasette.client.get(path)
     assert response.status_code == 200
     assert '<a href="/foo/-/search">' in response.text


### PR DESCRIPTION
Currently, this plugin doesn't respect permissions. So if you have this installed, it will always report the full number of full-text search tables despite permissions. This alters the behavior of the search plugin, making it check the `view-database` and `view-table` permissions on the resources before allowing them to be searched.