### PR TITLE
Remove a useless JS line in `autoescape()`

### DIFF
--- a/datasette_search_all/templates/search_all.html
+++ b/datasette_search_all/templates/search_all.html
@@ -96,7 +96,6 @@ function safe(s) {
 
 var autoescape = (fragments, ...inserts) => safe(fragments.map(
   (fragment, i) => {
-    var bit = fragment;
     var insert = (inserts[i] || '');
     if (!(insert instanceof Safe)) {
       insert = htmlEscape(insert.toString());


### PR DESCRIPTION
I hope I'm not missing something too trivial or I'll be embarrassed 😅 